### PR TITLE
No sesh

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
 'use strict';
 
-module.exports = {
-  flightLookup: require('./lib/flight-lookup')
-};
+module.exports = require('./lib/flight-lookup');

--- a/lib/flight-lookup.js
+++ b/lib/flight-lookup.js
@@ -49,7 +49,7 @@ module.exports = {
   },
 
   // map service response to useful form elements
-  mapFlight: function mapFlight(flight, sessionModel, dataLists) {
+  mapFlight: function mapFlight(flight, dataLists) {
     const departureDate = this.momentDate(flight.departure);
     const arrivalDate = this.momentDate(flight.arrival);
     let departCode = (departure) => this.search(dataLists.airports, {
@@ -58,7 +58,7 @@ module.exports = {
     }).countryCode;
 
     return {
-      flightNumber: sessionModel.get('plane-flight-number').toUpperCase(),
+      flightNumber: this.formatFlightNumber(flight.flightNumber).toUpperCase(),
       inwardDepartureCountryPlane: this.country(dataLists.countries, departCode(flight.departure)),
       inwardDepartureCountryPlaneCode: departCode(flight.departure),
       departureAirport: this.airport(dataLists.airports, flight.departure.port),

--- a/test/lib/flight-lookup.spec.js
+++ b/test/lib/flight-lookup.spec.js
@@ -75,14 +75,6 @@ describe('lib/flight-lookup', function() {
 
   describe('#mapFlight', function() {
     let flightData;
-    let sessionModel = {
-      get: function (key) {
-        return this.attributes[key];
-      },
-      attributes: {
-        'plane-flight-number': 'ku101'
-      }
-    };
     let dataLists = {
       countries: countries,
       airports: airports
@@ -95,8 +87,8 @@ describe('lib/flight-lookup', function() {
     });
 
     it('formats the data from the api into the correct format to use in the app', function() {
-      flightLookup.mapFlight(flightData, sessionModel, dataLists).should.deep.equal({
-        flightNumber: 'KU101',
+      flightLookup.mapFlight(flightData, dataLists).should.deep.equal({
+        flightNumber: 'KU0101',
         departureAirport: 'Dubai Airport',
         inwardDeparturePortPlaneCode: 'DXB',
         inwardDepartureCountryPlane: 'United Arab Emirates',


### PR DESCRIPTION
### Export flight-lookup directly  …
- it doesn't need to sit underneath a method name
### Remove dependency on session  …
- there is no session in flight lookup land!
- We shouldn't need it
- fixes an issue in which evw-self-serve and evw-hof referred to flight numbers by different keys in their respective sessions