### PR TITLE
DPS-1578 - Migrate EFF library to HO-wide Artifactory and Drone.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ pipeline:
       - npm i
       - npm test
     when:
-      event: [push, pull_request, tag]
+      event: [push, tag]
 
   publish_to_artifactory:
     image: node:6

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,26 @@
+pipeline:
+
+  test:
+    image: node:6
+    secrets:
+      - npm_config__auth
+      - npm_config_registry
+    commands:
+      - npm i
+      - npm test
+    when:
+      event: [push, pull_request, tag]
+
+  publish_to_artifactory:
+    image: node:6
+    secrets:
+      - npm_config__auth
+      - npm_config_registry
+    commands:
+      - npm publish
+    when:
+      event: [tag]
+
+matrix:
+  NPM_CONFIG_USERNAME:
+    - regt-build-bot

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,6 +5,8 @@ pipeline:
     secrets:
       - npm_config__auth
       - npm_config_registry
+    environment:
+      - NPM_CONFIG_ALWAYS_AUTH=true
     commands:
       - npm i
       - npm test
@@ -16,6 +18,8 @@ pipeline:
     secrets:
       - npm_config__auth
       - npm_config_registry
+    environment:
+      - NPM_CONFIG_ALWAYS_AUTH=true
     commands:
       - npm publish
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ pipeline:
     environment:
       - NPM_CONFIG_ALWAYS_AUTH=true
     commands:
+      - env
       - npm i
       - npm test
     when:

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-always-auth = true
-email = "noel.sharpe@digital.homeoffice.gov.uk"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+always-auth = true
+email = "noel.sharpe@digital.homeoffice.gov.uk"


### PR DESCRIPTION
- Add .drone.yml to build, test and publish to artifactory.
- Add .npmrc to enable publishting to any repo.
- Secrets are in Drone.
- Note the additional _ in the NPM_CONFIG__AUTH secret.
- Secrets are populated by drone and consumed by npm as environment variables.